### PR TITLE
Use script loops for SVG to limit tokenURI size

### DIFF
--- a/contracts/ConcentricCircles.sol
+++ b/contracts/ConcentricCircles.sol
@@ -36,23 +36,36 @@ contract ConcentricCircles is ERC721 {
     }
 
     function _generateSVG(uint256 tokenId) internal pure returns (string memory) {
-        string memory circles;
-        for (uint256 i = 0; i < tokenId; i++) {
-            circles = string(abi.encodePacked(
-                circles,
-                '<circle cx="50" cy="50" r="',
-                (10 + i * 2).toString(),
-                '" stroke="black" stroke-width="1" fill="none">',
-                '<animate attributeName="r" values="',
-                (10 + i * 2).toString(), ';', (12 + i * 2).toString(), ';', (10 + i * 2).toString(),
-                '" dur="5s" repeatCount="indefinite" />',
-                '</circle>'
-            ));
-        }
-        return string(abi.encodePacked(
-            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">',
-            circles,
-            '</svg>'
-        ));
+        string memory script = string(
+            abi.encodePacked(
+                "let svg=document.documentElement;",
+                "for(let i=0;i<", tokenId.toString(), ";i++){",
+                    "let c=document.createElementNS(\"http://www.w3.org/2000/svg\",\"circle\");",
+                    "let r=10+i*2;",
+                    "c.setAttribute(\"cx\",\"50\");",
+                    "c.setAttribute(\"cy\",\"50\");",
+                    "c.setAttribute(\"r\",r);",
+                    "c.setAttribute(\"stroke\",\"black\");",
+                    "c.setAttribute(\"stroke-width\",\"1\");",
+                    "c.setAttribute(\"fill\",\"none\");",
+                    "let anim=document.createElementNS(\"http://www.w3.org/2000/svg\",\"animate\");",
+                    "anim.setAttribute(\"attributeName\",\"r\");",
+                    "anim.setAttribute(\"values\",r+\";\"+(r+2)+\";\"+r);",
+                    "anim.setAttribute(\"dur\",\"5s\");",
+                    "anim.setAttribute(\"repeatCount\",\"indefinite\");",
+                    "c.appendChild(anim);",
+                    "svg.appendChild(c);",
+                "}"
+            )
+        );
+        return string(
+            abi.encodePacked(
+                '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">',
+                '<script><![CDATA[',
+                script,
+                ']]></script>',
+                '</svg>'
+            )
+        );
     }
 }

--- a/test/concentric.js
+++ b/test/concentric.js
@@ -2,23 +2,32 @@ const { expect } = require("chai");
 const { ethers } = require("hardhat");
 
 describe("ConcentricCircles", function () {
-  it("generates SVG with circles equal to tokenId", async function () {
-    const [owner] = await ethers.getSigners();
+  it("generates compact SVG using on-chain loops", async function () {
     const factory = await ethers.getContractFactory("ConcentricCircles");
     const contract = await factory.deploy();
-    await contract.mint(); // tokenId 1
-    const uri = await contract.tokenURI(1);
-    
-    // The URI should be a data URI with base64-encoded JSON
-    expect(uri).to.include("data:application/json;base64");
-    
-    // Decode the base64 JSON to check the contents
-    const base64Json = uri.replace("data:application/json;base64,", "");
-    const jsonString = Buffer.from(base64Json, 'base64').toString();
-    const metadata = JSON.parse(jsonString);
-    
-    expect(metadata.name).to.equal("Concentric Circle #1");
-    expect(metadata.description).to.equal("Animated on-chain concentric circles.");
-    expect(metadata.image).to.include("data:image/svg+xml;base64");
+
+    // Mint token #1 and check the basic metadata
+    await contract.mint();
+    const uri1 = await contract.tokenURI(1);
+    expect(uri1).to.include("data:application/json;base64");
+
+    const base64Json1 = uri1.replace("data:application/json;base64,", "");
+    const jsonString1 = Buffer.from(base64Json1, 'base64').toString();
+    const metadata1 = JSON.parse(jsonString1);
+    expect(metadata1.name).to.equal("Concentric Circle #1");
+    expect(metadata1.description).to.equal("Animated on-chain concentric circles.");
+    expect(metadata1.image).to.include("data:image/svg+xml;base64");
+
+    // Decode SVG to ensure it uses a script tag
+    const svgBase641 = metadata1.image.replace("data:image/svg+xml;base64,", "");
+    const svg1 = Buffer.from(svgBase641, 'base64').toString();
+    expect(svg1).to.include("<script><![CDATA[");
+
+    // Mint up to token #10 and compare URI lengths to ensure it stays compact
+    for (let i = 0; i < 9; i++) {
+      await contract.mint();
+    }
+    const uri10 = await contract.tokenURI(10);
+    expect(uri10.length - uri1.length).to.be.lessThan(200);
   });
 });


### PR DESCRIPTION
## Summary
- Build SVG images in ConcentricCircles using an embedded JavaScript loop to reduce tokenURI size growth
- Add tests ensuring SVG includes script-based loops and tokenURI size stays compact

## Testing
- `npm test` (fails: 403 Forbidden - GET https://registry.npmjs.org/hardhat)

------
https://chatgpt.com/codex/tasks/task_e_68a93dd2bda0832f9b0b049f15f7f04a